### PR TITLE
New UI: Hack to avoid the default theme's css being included the the ccnz theme is included

### DIFF
--- a/application/hooks/register_themes.php
+++ b/application/hooks/register_themes.php
@@ -40,7 +40,10 @@ class register_themes {
 			
 		$css_url = (Kohana::config("cache.cdn_css")) ? 
 			Kohana::config("cache.cdn_css") : url::base();
-		$theme_css[] = $css_url."themes/default/css/style.css";
+        // HACK: don't include the default style.css if using the ccnz theme
+        if ( Kohana::config("settings.site_style") != "ccnz" ) {
+            $theme_css[] = $css_url."themes/default/css/style.css";
+        }
 		
 		// 2. Extend the default theme
 		if ( Kohana::config("settings.site_style") != "default" )

--- a/themes/ccnz/views/header.php
+++ b/themes/ccnz/views/header.php
@@ -42,7 +42,6 @@
 						<li><a class="skip-link" href="#main" title="Skip to content" accesskey="[">Skip to content</a></li>						
 						<li>Useful Links:</li>
 						<?php nav::secondary_tabs($this_page); ?>
-						<li><a href="/page/index/4">Student Volunteer Army</a></li>
 					</ul>
 
 				<!-- searchform -->


### PR DESCRIPTION
It's a hack to avoid someone having to write css to unset all the 'default' styles before setting the styles for the theme.
