### PR TITLE
My .hidden CSS class got lost somewhere

### DIFF
--- a/themes/ccnz/css/style.css
+++ b/themes/ccnz/css/style.css
@@ -2309,3 +2309,8 @@ div.graph-holder, div.slider-holder {
 #threesteps form a:hover {
     background-color:#555;
 }
+
+.hidden {
+    position: absolute;
+    left: -99999px;	
+}


### PR DESCRIPTION
This just adds it back to the CSS. Without it you see the blurb above the 3 steps boxes
